### PR TITLE
Rename subcommittees to task forces

### DIFF
--- a/.github/ISSUE_TEMPLATE/task-force.md
+++ b/.github/ISSUE_TEMPLATE/task-force.md
@@ -1,15 +1,15 @@
 ---
-name: 'Propose new subcommittee'
-about: 'Used to propose a new subcommittee to the AC'
-title: '[NAME] Subcommittee'
-labels: 'Subcommittee'
+name: 'Propose a new task force'
+about: 'Used to propose a new task force to the AC and track its progress'
+title: '[NAME] Task Force'
+labels: 'task force'
 assignees: ''
 ---
 
 ### Focus
 
-<!-- Please describe the topic that the subcommittee plans to focus on.
-This can be framed in terms of a question that the subcommittee plans to come to conclusions which it then intended to present to the AC for resolution.
+<!-- Please describe the topic that the task force plans to focus on.
+This can be framed in terms of a question that the task force plans to come to conclusions which it then intended to present to the AC for resolution.
 It can also be simply to focus on authoring a document to clarify a point of better frame a topic that the AC is considering, either for internal usage or for publication by the AC (provided there's AC consensus, obviously).
 -->
 

--- a/WORKING_MODE.md
+++ b/WORKING_MODE.md
@@ -55,15 +55,15 @@ The facilitator generally acts as a liaison with the TSC.
 The facilitator is responsible for making sure everyone feels welcomed and heard, and enforcing the code of conduct if necessary.
 
 
-## Subcommittees
+## Task forces
 
-A subcommittee can be formed by a group of AC members who wish to focus on a particular topic for a fixed (generally short) period of time.
+A task force can be formed by a group of AC members who wish to focus on a particular topic for a fixed (generally short) period of time.
 
-A subcommittee must have a [facilitator][], an area of focus, a set of deliverables, and an end date at which it presents its recommendations to the AC or requests to be renewed.
+A task force must have a [facilitator][], an area of focus, a set of deliverables, and an end date at which it presents its recommendations to the AC or requests to be renewed.
 
-A subcommittee may include non-AC members. Its proceedings are public.
+A task force may include non-AC members. Its proceedings are public.
 
-Subcommittees do not have any decision making authority. They only provide recommendations to the AC.
+Task forces do not have any decision making authority. They only provide recommendations to the AC.
 
 
 ## Activities
@@ -80,7 +80,7 @@ In practice:
 * Review of [intent to implement issues (I2I)][I2I] either on the I2I itself or in a specific issue.
 * Advice and discussions on topics brought up by the TSC.
 * Publication of “opinions” on specific topics (audience: TSC, [collaborators][collaborator], but also platform implementers, devs, etc.).
-* [Subcommittees](#Subcommittees) to work on specific projects (proceedings must also be public).
+* [Task forces](#task-forces) to work on specific projects (proceedings must also be public).
 * Video conferences and calls as needed, potentially in sub-committees (to account for the size of the AC). Notes are public.
 * Liaison with standards organizations and groups ([W3C][], [WHATWG][], [WICG][], [IETF][], etc.).
 * Two single-day face to face meetings per year, aligned (if possible) with [AMP Conf][amp-conf] and AMP Contributor Summit.


### PR DESCRIPTION
This was suggested in both meetings.

Fast-tracking as it's only editorial.